### PR TITLE
Increased max_lenth of nmap_command from 2048 to 8096 for masscan

### DIFF
--- a/master/django_scantron/models.py
+++ b/master/django_scantron/models.py
@@ -87,7 +87,7 @@ class NmapCommand(models.Model):
     )
     nmap_command = models.CharField(
         unique=True,
-        max_length=2048,
+        max_length=8096,
         verbose_name='nmap command'
     )
 


### PR DESCRIPTION
Fixes https://github.com/rackerlabs/scantron/issues/14