### PR TITLE
Update initial_setup.sh so that it can run on OSX

### DIFF
--- a/initial_setup.sh
+++ b/initial_setup.sh
@@ -37,10 +37,26 @@ cp master/scantron_secrets.json.empty master/scantron_secrets.json
 # Generate random Django key.
 # https://www.howtogeek.com/howto/30184/10-ways-to-generate-a-random-password-from-the-command-line/
 echo "[*] Generating random Django Key and database passwords."
-DJANGO_KEY=`< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-64};echo;`
-DATABASE_PASSWORD=`< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-32};echo;`
+# Locale needs to be set for OSX, else tr responds with "tr: Illegal byte sequence"
+# https://unix.stackexchange.com/questions/45404/why-cant-tr-read-from-dev-urandom-on-osx
+if [[ `uname` == "Darwin" ]] 
+then
+   DJANGO_KEY=`< /dev/urandom LC_ALL=C tr -dc _A-Z-a-z-0-9 | head -c${1:-64};echo;`
+   DATABASE_PASSWORD=`< /dev/urandom LC_ALL=C tr -dc _A-Z-a-z-0-9 | head -c${1:-32};echo;`
+else
+   DJANGO_KEY=`< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-64};echo;`
+   DATABASE_PASSWORD=`< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-32};echo;`
+fi
 
-sed -i "s/REPLACE_THIS_DJANGO_KEY/$DJANGO_KEY/g" master/scantron_secrets.json
-sed -i "s/REPLACE_THIS_DATABASE_PASSWORD/$DATABASE_PASSWORD/g" master/scantron_secrets.json
+# -i requires additional arguments on OSX, else it responds with "sed: 1: "<filename>": invalid command code"
+# https://markhneedham.com/blog/2011/01/14/sed-sed-1-invalid-command-code-r-on-mac-os-x/
+if [[ `uname` == "Darwin" ]] 
+then
+   sed -i "" "s/REPLACE_THIS_DJANGO_KEY/$DJANGO_KEY/g" master/scantron_secrets.json
+   sed -i "" "s/REPLACE_THIS_DATABASE_PASSWORD/$DATABASE_PASSWORD/g" master/scantron_secrets.json
+else 
+   sed -i "s/REPLACE_THIS_DJANGO_KEY/$DJANGO_KEY/g" master/scantron_secrets.json
+   sed -i "s/REPLACE_THIS_DATABASE_PASSWORD/$DATABASE_PASSWORD/g" master/scantron_secrets.json
+fi
 
 echo "[+] Done!"


### PR DESCRIPTION
The "tr" command requires a LOCALE to be set when reading from /dev/urandom otherwise it exits with "tr: illegal byte sequence"

The "sed" command requires additional arguments to be passed to -i