### PR TITLE
fqdn update to 1.2.0

### DIFF
--- a/master/requirements/base.txt
+++ b/master/requirements/base.txt
@@ -26,7 +26,7 @@ djangorestframework==3.9.2
 drf-yasg==1.16.1
 
 # fqdn
-fqdn==1.1.0
+fqdn==1.2.0
 
 # ipython
 ipython==6.4.0


### PR DESCRIPTION
I released a new minor version of `fqdn` today on PyPI that fixes corner use cases:
- allow numbers and dashes in labels after the first + tests
- 63 octet labels + tests

https://pypi.org/project/fqdn/1.2.0/
https://github.com/ypcrts/fqdn
