### PR TITLE
Capping out number of chars in Scan Command to 255 in master/django_s…

### DIFF
--- a/master/django_scantron/templates/django_scantron/scheduled_scan_list.html
+++ b/master/django_scantron/templates/django_scantron/scheduled_scan_list.html
@@ -35,7 +35,7 @@ Scheduled Scans
             <td>{{ scan.scan_agent }}</td>
             <td>{{ scan.start_time|date:"H:i" }}</td>
             <td>{{ scan.scan_binary }}</td>
-            <td>{{ scan.scan_binary }} {{ scan.scan_command }}</td>
+            <td>{{ scan.scan_binary }} {{ scan.scan_command | truncatechars:255 }}</td>
             <td>{{ scan.scan_status }}</td>
             <td>{{ scan.completed_time|date:"Y-m-j H:i:s" }}</td>
             {% if scan.scan_binary == "nmap" %}


### PR DESCRIPTION
…cantron/templates/django_scantron/scheduled_scan_list.html