### PR TITLE
add missing version info for postgresql install

### DIFF
--- a/ansible-playbooks/roles/console/vars/main.yml
+++ b/ansible-playbooks/roles/console/vars/main.yml
@@ -10,7 +10,7 @@ install_packages:
   - nginx
   - nmap
   - postfix
-  - postgresql-contrib
+  - "postgresql-contrib-{{ postgresql_version }}"
   - python-dev
   - python3-pip
   - python-virtualenv

--- a/ansible-playbooks/roles/console/vars/main.yml
+++ b/ansible-playbooks/roles/console/vars/main.yml
@@ -10,7 +10,7 @@ install_packages:
   - nginx
   - nmap
   - postfix
-  - "postgresql-contrib-{{ postgresql_version }}"
+  - postgresql-{{ postgresql_version }}
   - python-dev
   - python3-pip
   - python-virtualenv


### PR DESCRIPTION
Signed-off-by: tothi <tothi@users.noreply.github.com>

by default the console config playbook install the latest postgresql (via postgresql-contrib apt package), but tries to use the one specified in the postgresql_version variable later (12). this is an inconsistency (now 13 is the latest, so the ansible-playbook fails). 

easy solution here is to install not the latest, but the specified one.
